### PR TITLE
Redesign the autoplay run row

### DIFF
--- a/apps/web/src/components/composer.tsx
+++ b/apps/web/src/components/composer.tsx
@@ -85,6 +85,7 @@ type ProgressionRunView =
       phase: ActiveProgressionRunPhase
       nextAction: string
       afterCycles: number
+      remainingCycles?: number
       remainingSeconds?: number
     }
 
@@ -793,7 +794,9 @@ export function Composer(props: PatternStateBindings & {
         Math.ceil(remainingCycles / cyclesPerSecond),
       )
       if (current.remainingSeconds === remainingSeconds) return
-      setProgressionRun({ ...current, remainingSeconds })
+      // The meter reads the same cycle sample the countdown does, so the fill
+      // and the clock never disagree about how much of the hold is left.
+      setProgressionRun({ ...current, remainingCycles, remainingSeconds })
     }
 
     showPhase('starting', initialStep)
@@ -1137,61 +1140,82 @@ function ProgressionRow(props: {
     ? props.step?.nextAction
     : props.run.nextAction
   const status = progressionRunStatus(props.run, props.notice)
+  const progress = progressionWaitProgress(props.run)
 
   return (
     <div
-      className={`progression-row ${running ? 'running' : ''}`}
+      className={`progression-row phase-${props.run.phase} ${running ? 'running' : ''}`}
     >
       <span className="sr-only" role="status">
         {progressionRunAnnouncement(props.run, action, props.notice)}
       </span>
       <span className="chip-label">AUTOPLAY</span>
       <div className="progression-body">
-        <div className="progression-copy">
+        <div className="progression-head">
           {status ? (
             <strong role={props.run.phase === 'waiting' ? 'timer' : undefined}>
               {status}
             </strong>
           ) : null}
-          {action ? (
-            <span>
-              {props.overrideQueued ? <em>YOUR NEXT</em> : null}
-              {action}
+          {running ? (
+            <span
+              aria-hidden="true"
+              className={`progression-meter ${progress === null ? 'indeterminate' : ''}`}
+            >
+              <span
+                className="progression-meter-fill"
+                style={progress === null ? undefined : { width: `${progress * 100}%` }}
+              />
             </span>
           ) : null}
-        </div>
-        <div className={`progression-controls ${running ? 'running' : ''}`}>
-          {!running ? (
-            <select
-              aria-label="Run duration"
-              className="run-duration"
-              disabled={props.busy}
-              value={props.durationMs}
-              onChange={(event) => props.onDurationChange(Number(event.target.value))}
+          <div className="progression-controls">
+            {!running ? (
+              <select
+                aria-label="Run duration"
+                className="run-duration"
+                disabled={props.busy}
+                value={props.durationMs}
+                onChange={(event) => props.onDurationChange(Number(event.target.value))}
+              >
+                {PROGRESSION_RUN_DURATION_PRESETS_MS.map((durationMs) => (
+                  <option key={durationMs} value={durationMs}>
+                    {progressionRunDurationLabel(durationMs)}
+                  </option>
+                ))}
+              </select>
+            ) : null}
+            {props.run.phase === 'waiting' ? (
+              <button className="chrome run-now" onClick={props.onXfadeNow}>
+                XFADE NOW
+              </button>
+            ) : null}
+            <button
+              className={`primary ${running ? 'stop' : ''}`}
+              disabled={!running && props.busy}
+              onClick={running ? props.onStop : props.onStart}
             >
-              {PROGRESSION_RUN_DURATION_PRESETS_MS.map((durationMs) => (
-                <option key={durationMs} value={durationMs}>
-                  {progressionRunDurationLabel(durationMs)}
-                </option>
-              ))}
-            </select>
-          ) : null}
-          {props.run.phase === 'waiting' ? (
-            <button className="chrome run-now" onClick={props.onXfadeNow}>
-              XFADE NOW
+              {running ? 'STOP RUN' : 'START RUN'}
             </button>
-          ) : null}
-          <button
-            className={`primary ${running ? 'stop' : ''}`}
-            disabled={!running && props.busy}
-            onClick={running ? props.onStop : props.onStart}
-          >
-            {running ? 'STOP RUN' : 'START RUN'}
-          </button>
+          </div>
         </div>
+        {action ? (
+          <p className="progression-action" title={action}>
+            {props.overrideQueued ? <em>YOUR NEXT</em> : null}
+            {action}
+          </p>
+        ) : null}
       </div>
     </div>
   )
+}
+
+/** How much of the current hold has already played, or null when the run is
+ * not counting down a hold and the meter should read as indeterminate. */
+function progressionWaitProgress(run: ProgressionRunView): number | null {
+  if (run.phase !== 'waiting') return null
+  if (run.remainingCycles === undefined || run.afterCycles <= 0) return null
+  const elapsed = 1 - run.remainingCycles / run.afterCycles
+  return Math.min(1, Math.max(0, elapsed))
 }
 
 function progressionRunAnnouncement(

--- a/apps/web/src/components/purple-studio.browser.test.tsx
+++ b/apps/web/src/components/purple-studio.browser.test.tsx
@@ -56,6 +56,10 @@ const studio = vi.hoisted(() => ({
   transitionResults: [] as unknown[],
   progressionWaitCalls: [] as number[],
   progressionWaitGates: [] as Promise<void>[],
+  /** The live run's countdown reporter, so a test can advance the wait. */
+  reportProgressionWait: null as
+    | ((remainingCycles: number, cyclesPerSecond: number) => void)
+    | null,
   prepareValidationCalls: 0,
   stopCalls: 0,
   storedKey: 'browser-test-key' as string | null,
@@ -323,6 +327,7 @@ vi.mock('@purple/ui/use-playback', async () => {
         onProgress?: (remainingCycles: number, cyclesPerSecond: number) => void,
       ): Promise<EvalResult> => {
         studio.progressionWaitCalls.push(cycles)
+        studio.reportProgressionWait = onProgress ?? null
         onProgress?.(cycles, 0.5)
         const gate = studio.progressionWaitGates.shift()
         if (!gate) {
@@ -394,6 +399,7 @@ beforeEach(() => {
   studio.transitionResults.length = 0
   studio.progressionWaitCalls.length = 0
   studio.progressionWaitGates.length = 0
+  studio.reportProgressionWait = null
   studio.prepareValidationCalls = 0
   studio.stopCalls = 0
   studio.storedKey = 'browser-test-key'
@@ -1009,7 +1015,7 @@ describe('Purple studio browser flow', () => {
     expect(studio.saveChatCalls).toBeGreaterThan(savesBeforeUndo)
   })
 
-  it('keeps idle run controls below the progression copy', async () => {
+  it('keeps idle run controls off the progression copy line', async () => {
     await renderGeneratedPattern()
 
     const action = screen.getByText(NEXT_ACTION)
@@ -1018,8 +1024,10 @@ describe('Purple studio browser flow', () => {
 
     expect(controls).not.toBeNull()
     expect(row).not.toBeNull()
-    expect(controls?.getBoundingClientRect().top)
-      .toBeGreaterThanOrEqual(action.getBoundingClientRect().bottom)
+    // Controls ride the status line, so the wrapping copy never shares a row
+    // with them and cannot squeeze them into an overflow.
+    expect(controls?.getBoundingClientRect().bottom)
+      .toBeLessThanOrEqual(action.getBoundingClientRect().top)
     expect(row?.scrollWidth).toBeLessThanOrEqual(row?.clientWidth ?? 0)
   })
 
@@ -1257,6 +1265,12 @@ describe('Purple studio browser flow', () => {
     await startModelPlannedRun()
 
     expect(await screen.findByText('NEXT IN 1:01:52')).toBeVisible()
+    const meterFill = () =>
+      document.querySelector<HTMLElement>('.progression-meter-fill')
+    expect(meterFill()?.style.width).toBe('0%')
+    act(() => studio.reportProgressionWait?.(PLANNED_CYCLES / 4, 0.5))
+    await waitFor(() => expect(meterFill()?.style.width).toBe('75%'))
+
     const action = screen.getByText(NEXT_ACTION)
     const actionStyle = getComputedStyle(action)
     expect(action).toBeVisible()

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -381,76 +381,150 @@ a { color: var(--accent); }
   background: color-mix(in srgb, var(--hot) 18%, transparent);
   box-shadow: var(--glow-hot);
 }
+/* Autoplay: a live status line over the description of the next move. */
 .progression-row {
   flex: none;
   min-width: 0;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: start;
-  gap: 8px;
-  padding: 7px 0;
+  gap: 10px;
+  padding: 8px 0;
   border-top: 1px solid color-mix(in srgb, var(--active) 16%, transparent);
   border-bottom: 1px solid color-mix(in srgb, var(--active) 16%, transparent);
 }
 .progression-row .chip-label {
-  padding-top: 3px;
+  display: flex;
+  align-items: center;
+  /* Match the control height so the label sits on the status line. */
+  height: 25px;
   color: color-mix(in srgb, var(--active) 58%, transparent);
+}
+/* A run in progress carries the same pulsing dot as the transport LED. */
+.progression-row.running .chip-label::before {
+  content: '';
+  flex: none;
+  width: 5px;
+  height: 5px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: var(--active);
+  box-shadow: var(--glow-active-sm);
+  animation: glow-pulse 2s ease-in-out infinite;
 }
 .progression-body {
   min-width: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  align-items: stretch;
-  gap: 8px;
+  gap: 6px;
 }
-.progression-copy {
+.progression-head {
   min-width: 0;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: baseline;
-  gap: 8px;
-  font: 400 10px var(--font-mono);
+  min-height: 25px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
 }
-.progression-copy strong {
+.progression-head strong {
   flex: none;
   color: var(--active);
-  font-size: 9px;
-  letter-spacing: 0.1em;
+  font: 600 9px var(--font-mono);
+  letter-spacing: 0.16em;
+  font-variant-numeric: tabular-nums;
 }
-.progression-copy span {
+.phase-idle .progression-head strong { color: var(--text-dim); }
+.phase-starting .progression-head strong,
+.phase-generating .progression-head strong { color: var(--warn); }
+.phase-transitioning .progression-head strong { color: var(--hot); }
+/* Elapsed share of the current hold, so the wait reads at a glance instead of
+   only through the clock. Phases that have no deadline sweep instead. */
+.progression-meter {
+  flex: 1 1 60px;
+  min-width: 48px;
+  height: 3px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--active) 18%, transparent);
+}
+.progression-meter-fill {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--active) 70%, transparent);
+  box-shadow: var(--glow-active-sm);
+  /* The countdown ticks once a second; ease across it so the fill glides. */
+  transition: width 1s linear;
+}
+.progression-meter.indeterminate .progression-meter-fill {
+  width: 35%;
+  animation: meter-sweep 1.6s ease-in-out infinite;
+}
+.phase-starting .progression-meter,
+.phase-generating .progression-meter {
+  background: color-mix(in srgb, var(--warn) 18%, transparent);
+}
+.phase-starting .progression-meter-fill,
+.phase-generating .progression-meter-fill {
+  background: color-mix(in srgb, var(--warn) 70%, transparent);
+  box-shadow: var(--glow-warn-sm);
+}
+.phase-transitioning .progression-meter {
+  background: color-mix(in srgb, var(--hot) 18%, transparent);
+}
+.phase-transitioning .progression-meter-fill {
+  background: color-mix(in srgb, var(--hot) 70%, transparent);
+  box-shadow: none;
+}
+@keyframes meter-sweep {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(286%); }
+}
+.progression-action {
   min-width: 0;
-  color: var(--text-dim);
-  line-height: 1.45;
+  margin: 0;
+  /* Bound the block: the composer shares its height with the transcript, and a
+     long plan should not push the conversation off screen. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--text) 62%, transparent);
+  font: 400 11.5px/1.55 var(--font-display);
   overflow-wrap: anywhere;
 }
-.progression-copy span:only-child { grid-column: 1 / -1; }
-.progression-copy em {
+.progression-action em {
   margin-right: 7px;
   color: var(--accent);
-  font-size: 8px;
+  font: 600 8px var(--font-mono);
   font-style: normal;
-  font-weight: 600;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.16em;
   white-space: nowrap;
+  vertical-align: 1px;
 }
 .progression-controls {
-  min-width: 0;
+  flex: none;
+  margin-left: auto;
   display: flex;
-  justify-content: flex-end;
   align-items: center;
-  gap: 8px;
+  /* Keep the destructive control clear of the one people reach for often. */
+  gap: 24px;
 }
-.progression-controls.running {
-  grid-template-columns: auto minmax(24px, 1fr) auto;
-  display: grid;
-}
-.progression-row .primary { flex: none; padding: 4px 9px; }
+.progression-row .primary { flex: none; padding: 4px 10px; }
 .progression-row .run-now {
   flex: none;
-  padding: 4px 7px;
+  padding: 4px 9px;
   white-space: nowrap;
+  border-color: color-mix(in srgb, var(--active) 30%, transparent);
+  color: color-mix(in srgb, var(--active) 85%, transparent);
 }
-.progression-controls.running .primary.stop { grid-column: 3; }
+.progression-row .run-now:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--active) 60%, transparent);
+  background: color-mix(in srgb, var(--active) 10%, transparent);
+  color: var(--active);
+  box-shadow: var(--glow-active);
+}
 .run-duration {
   height: 25px;
   padding: 0 5px;
@@ -468,15 +542,27 @@ a { color: var(--accent); }
 .run-duration:focus {
   border-color: color-mix(in srgb, var(--active) 45%, transparent);
 }
+/* Stopping a run is rarely the point of the row, so it reads as an outline
+   until it is hovered. */
 .progression-row .primary.stop {
-  border-color: color-mix(in srgb, var(--hot) 35%, transparent);
-  background: color-mix(in srgb, var(--hot) 10%, transparent);
-  color: var(--hot);
+  border-color: color-mix(in srgb, var(--hot) 28%, transparent);
+  background: transparent;
+  color: color-mix(in srgb, var(--hot) 80%, transparent);
 }
 .progression-row .primary.stop:hover:not(:disabled) {
   border-color: color-mix(in srgb, var(--hot) 65%, transparent);
-  background: color-mix(in srgb, var(--hot) 18%, transparent);
+  background: color-mix(in srgb, var(--hot) 14%, transparent);
+  color: var(--hot);
   box-shadow: var(--glow-hot);
+}
+@media (prefers-reduced-motion: reduce) {
+  .progression-row.running .chip-label::before { animation: none; }
+  .progression-meter-fill { transition: none; }
+  .progression-meter.indeterminate .progression-meter-fill {
+    width: 100%;
+    animation: none;
+    opacity: 0.5;
+  }
 }
 /* Prompt input */
 .prompt-form { flex: none; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: end; }


### PR DESCRIPTION
The autoplay row reported a run through a countdown and a five line block of 10px monospace prose, with the controls stranded below it and the destructive STOP RUN carrying the most visual weight.

Timing, progress, and controls now share one status line above the plan description.

- A meter shows the elapsed share of the current hold. It reads the same cycle sample the countdown does, so the fill and the clock cannot disagree. Phases without a deadline sweep instead.
- Status text and meter take the phase color the app already uses elsewhere: active while holding, warn while generating, hot while crossfading.
- The plan description moves to the display font and clamps to three lines, so a long plan cannot push the transcript off screen. The full text stays in the DOM and in the `title`.
- XFADE NOW reads as the constructive action; STOP RUN drops to an outline until hovered, keeping the separation the layout test asserts.
- A pulsing dot on the label marks a live run, matching the transport LED.
- Reduced motion keeps the meter static.

`keeps idle run controls below the progression copy` encoded the old stacking, so it was retargeted to the new intent: controls sit above the copy, and the row still does not overflow. A new assertion checks the meter fill tracks elapsed cycles.

`pnpm run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6n2iBLBjPnfyLu7uDjc2E